### PR TITLE
change default version for stitching-db postgres

### DIFF
--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -212,7 +212,7 @@ services:
       - 4630:8080
 
   stitching-db:
-    image: postgres
+    image: postgres:9.6
     restart: always
     environment:
       - POSTGRES_DB=emstitch


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
change default version for stitching-db postgres 11


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[] No
```
You probably need to bring down all services with volume removal, if you did some actions on data files within new postgres 12 (latest) version:
```
./ccd compose down -v
```
and start again:
```
./ccd compose up -d
```