### PR TITLE
RIA-6162 Add new liberata mock accounts and spring profile for paymen…

### DIFF
--- a/bin/wiremock.sh
+++ b/bin/wiremock.sh
@@ -474,6 +474,10 @@ curl -X POST \
 http://localhost:8991/__admin/mappings/new
 
 #PBA accounts
+# new waysToPay accounts:
+# "PBAFUNC12345" Successful account
+# "PBAFUNC12350" Deleted account
+# "PBAFUNC12355" Account on hold
 curl -X POST \
 --data '{
           "request": {
@@ -503,7 +507,10 @@ curl -X POST \
                   "PBA0087535",
                   "PBA0087240",
                   "PBA0088063",
-                  "PBA0087442"
+                  "PBA0087442",
+                  "PBAFUNC12345",
+                  "PBAFUNC12350",
+                  "PBAFUNC12355"
                 ],
                 "contactInformation": [
                   {

--- a/compose/payments.yml
+++ b/compose/payments.yml
@@ -33,6 +33,7 @@ services:
       SPRING_LIQUIBASE_ENABLED: "true"
       AZURE_APPLICATION_INSIGHTS_INSTRUMENTATION_KEY: "dummy"
       TRUSTED_S2S_SERVICE_NAMES: "cmc,iac,xui_webapp,payment_app"
+      SPRING_PROFILES_ACTIVE: "${PAYMENTS_API_PROFILE:-liberataMock}"
     ports:
       - 8083:8080
     depends_on:


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6162](https://tools.hmcts.net/jira/browse/RIA-6162)


### Change description ###
- Added liberata account names to the wiremock command that loads mock accounts into Wiremock
- Added environment variable to set payments-api's profile (defaulting to `liberataMock`) to make payments-api retrieve mock liberata accounts for local development


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
