### PR TITLE
RIA-6266 Stitching api url: stitching-api:4630

### DIFF
--- a/compose/evidence-management.yml
+++ b/compose/evidence-management.yml
@@ -61,7 +61,7 @@ services:
       IDAM_API_BASE_URI: http://sidam-api:5000
       OPEN_ID_API_BASE_URI: http://sidam-api:5000/o
       S2S_BASE_URI: http://service-auth-provider-api:8080
-      EM_STITCHING_API_URL: http://stitching-api:8080
+      EM_STITCHING_API_URL: http://stitching-api:4630
       CALLBACK_DOMAIN: rpa-em-ccd-orchestrator
       APPINSIGHTS_INSTRUMENTATIONKEY: key
       ENABLE_LIQUIBASE: "true"


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6266](https://tools.hmcts.net/jira/browse/RIA-6266), [RIA-6265](https://tools.hmcts.net/jira/browse/RIA-6265), + any process that relied on rpe-em-ccd-orchestrator to call stitching-api


### Change description ###
- Updated the stitching-api's url to `stitching-api:4630`. Rpe-em-ccd-orchestrator'r calls were refused to `stitching-api:8080`.
- As part of the fix, stitching-api also needs to be added to the hosts file in Windows

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
