### PR TITLE
RIA-8202 Add panelMemberType refData response to Wiremock

### DIFF
--- a/bin/wiremock-hearings-tab/wiremock-panelmembertype.sh
+++ b/bin/wiremock-hearings-tab/wiremock-panelmembertype.sh
@@ -20,10 +20,47 @@ curl -X POST \
         }
     },
     "response": {
-        "status": 404,  
-        "headers": {
-          "Content-Type": "application/json"
-        }
+        "list_of_values": [
+            {
+                "category_key": "PanelMemberType",
+                "key": "84",
+                "value_en": "Tribunal Judge",
+                "value_cy": "",
+                "hint_text_en": "",
+                "hint_text_cy": "",
+                "lov_order": null,
+                "parent_category": "",
+                "parent_key": "",
+                "active_flag": "Y",
+                "child_nodes": null
+            },
+            {
+                "category_key": "PanelMemberType",
+                "key": "65",
+                "value_en": "President of Tribunal",
+                "value_cy": "",
+                "hint_text_en": "",
+                "hint_text_cy": "",
+                "lov_order": null,
+                "parent_category": "",
+                "parent_key": "",
+                "active_flag": "Y",
+                "child_nodes": null
+            },
+            {
+                "category_key": "PanelMemberType",
+                "key": "",
+                "value_en": "Resident Immigration Judge",
+                "value_cy": "",
+                "hint_text_en": "",
+                "hint_text_cy": "",
+                "lov_order": null,
+                "parent_category": "",
+                "parent_key": "",
+                "active_flag": "Y",
+                "child_nodes": null
+            }
+        ]
     }
 }' \
 http://localhost:8991/__admin/mappings/new


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8202](https://tools.hmcts.net/jira/browse/RIA-8202)


### Change description ###
- Add Wiremock stubbing of refData call to `panelMemberType`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
