### PR TITLE
DIAC-1058 Fix local docmosis tornado service

### DIFF
--- a/compose/tornado.yml
+++ b/compose/tornado.yml
@@ -12,3 +12,4 @@ services:
     environment:
       DOCMOSIS_KEY: "${DOCMOSIS_ACCESS_KEY}"
       DOCMOSIS_SITE: "${DOCMOSIS_SITE}"
+      DOCMOSIS_ADMINPW: "${DOCMOSIS_ADMIN_PASSWORD:-admin}"

--- a/iac-ft.env
+++ b/iac-ft.env
@@ -207,13 +207,19 @@ export AZURE_SERVICE_BUS_CONNECTION_STRING="Endpoint=sb://ia-servicebus-demo.ser
 export CALLBACK_BUS_CONNECTION_STRING="Endpoint=sb://ia-servicebus-demo.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=mcO/DOZsZiC3Ecb7ip7BpKA65k9zuKapBLP4vq7OAoI="
 export AM_ROLE_ASSIGNMENT_ADMIN_PWD=Pa55word11
 export DB_EXTERNAL_PORT=5050
+
+# Variables for local docmosis tornado service
+export DOCMOSIS_ACCESS_KEY=3RAD-KLTH-JALP-IKIA-EBBH-2ELH-UBKQ-HS07-E7E1-B-D46C
+export DOCMOSIS_SITE="Free Trial Tornado"
+export DOCMOSIS_TEMPLATE_PATH=${IAC_FT_REPOS_PATH}/docmosis-templates
+
 export DOCMOSIS_ENDPOINT=https://docmosis.aat.platform.hmcts.net
-export DOCMOSIS_ACCESS_KEY=dyVv8pXwQ03RRyJZQIPX2RWP9LgJJGTU08kc9dA8ATJoA9EZXQEWe7L1Uwe
 export DOCMOSIS_RENDER_URL=/rs/render
 export DOCMOSIS_STATUS_URL=/rs/status
 export DOCMOSIS_CONVERT_URL=/rs/convert
 export EM_DOCMOSIS_CONVERT_ENDPOINT=https://docmosis.aat.platform.hmcts.net/rs/convert
 export EM_DOCMOSIS_RENDER_ENDPOINT=https://docmosis.aat.platform.hmcts.net/rs/render
+
 export IA_EM_STITCHING_ENABLED=true
 export IA_CTSC_EMAIL=ia-ctsc@fake.hmcts.net
 export APPINSIGHTS_INSTRUMENTATIONKEY=SomeRandomStringForLocalDocker
@@ -236,6 +242,5 @@ export AZURE_SERVICE_BUS_FEATURE_TOGGLE=false
 export WA_DLQ_PROCESS_ENABLED=true
 export AZURE_SERVICE_BUS_MESSAGE_AUTHOR=rajesh
 export LAUNCH_DARKLY_ACCESS_TOKEN=replace_me
-export DOCMOSIS_SITE="Free Trial Tornado"
 export SYSTEM_USER_NAME=ccd-system-user@fake.hmcts.net
 export SYSTEM_PASS_WORD=London40


### PR DESCRIPTION

### Change description ###

This should fix the tornado service to run locally. It's not enabled by default, but can be enabled in `default.conf` under compose dir.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
